### PR TITLE
Windows support

### DIFF
--- a/map.go
+++ b/map.go
@@ -74,6 +74,7 @@ func noslash(p string) string {
 // slashdir returns path.Dir(p), but special-cases paths not beginning
 // with a slash to be in the root.
 func slashdir(p string) string {
+	p = filepath.ToSlash(p)
 	d := pathpkg.Dir(p)
 	if d == "." {
 		return "/"
@@ -88,7 +89,7 @@ func slash(p string) string {
 	if p == "." {
 		return "/"
 	}
-	return "/" + strings.TrimPrefix(p, "/")
+	return "/" + strings.TrimPrefix(filepath.ToSlash(p), "/")
 }
 
 type mapFile struct {

--- a/sub.go
+++ b/sub.go
@@ -47,11 +47,11 @@ type subFetcherOpenerFS struct{ subFS }
 var _ FetcherOpener = subFetcherOpenerFS{}
 
 func (s subFS) resolve(path string) string {
-	return filepath.Join(s.prefix, strings.TrimPrefix(path, "/"))
+	return filepath.ToSlash(filepath.Join(s.prefix, strings.TrimPrefix(filepath.ToSlash(path), "/")))
 }
 
 func (s subFS) stripPrefix(path string) string {
-	return "/" + strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(path, "/"), strings.TrimPrefix(s.prefix, "/")), "/")
+	return "/" + strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(filepath.ToSlash(path), "/"), strings.TrimPrefix(filepath.ToSlash(s.prefix), "/")), "/")
 }
 
 func (s subFS) Lstat(path string) (os.FileInfo, error) {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -47,6 +47,10 @@ func Write(t *testing.T, fs rwvfs.FileSystem) {
 	if err != nil {
 		t.Fatalf("%s: ReadAll: %s", label, err)
 	}
+	err = r.Close()	
+	if err != nil {
+		t.Fatalf("%s: r.Close: %s", label, err)
+	}
 	if !bytes.Equal(output, input) {
 		t.Errorf("%s: got output %q, want %q", label, output, input)
 	}
@@ -68,6 +72,10 @@ func Write(t *testing.T, fs rwvfs.FileSystem) {
 	output, err = ioutil.ReadAll(r)
 	if err != nil {
 		t.Fatalf("%s: ReadAll: %s", label, err)
+	}
+	err = r.Close()	
+	if err != nil {
+		t.Fatalf("%s: r.Close: %s", label, err)
 	}
 	if !bytes.Equal(output, input) {
 		t.Errorf("%s: got output %q, want %q", label, output, input)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -47,7 +47,7 @@ func Write(t *testing.T, fs rwvfs.FileSystem) {
 	if err != nil {
 		t.Fatalf("%s: ReadAll: %s", label, err)
 	}
-	err = r.Close()	
+	err = r.Close()
 	if err != nil {
 		t.Fatalf("%s: r.Close: %s", label, err)
 	}
@@ -73,7 +73,7 @@ func Write(t *testing.T, fs rwvfs.FileSystem) {
 	if err != nil {
 		t.Fatalf("%s: ReadAll: %s", label, err)
 	}
-	err = r.Close()	
+	err = r.Close()
 	if err != nil {
 		t.Fatalf("%s: r.Close: %s", label, err)
 	}


### PR DESCRIPTION
- MkdirAll - converting path to Unix style before processing, passing Unix-style elements to underlying FS
- Glob - converting entries to Unix style, using path.Match instead of filepath.Match
- walkable FS now uses slash as file separator instead of OS-specific one, the same does sub FS and map FS
- "go test" now passes on Windows