### PR TITLE
cloudstoragevfs: keep default client to avoid fetching a new oauth token on each request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4
+  - 1.6
 
 before_install:
   - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph


### PR DESCRIPTION
Fetching a new oauth token on each request was causing 500s, probably hitting some rate limit.
